### PR TITLE
Add Domain Layer

### DIFF
--- a/app/src/main/java/com/sandoval/mypokedex/data/models/pokedex_list/PokedexListResponse.kt
+++ b/app/src/main/java/com/sandoval/mypokedex/data/models/pokedex_list/PokedexListResponse.kt
@@ -1,8 +1,13 @@
 package com.sandoval.mypokedex.data.models.pokedex_list
 
+import com.sandoval.mypokedex.domain.models.pokedex_list.DPokedexListResponse
+
 data class PokedexListResponse(
-    val count: Int?,
-    val next: String?,
-    val previous: String?,
-    val results: List<Result>?
-)
+    val count: Int?, val next: String?, val previous: String?, val results: List<Result>?
+) {
+    fun toDomainObject() = DPokedexListResponse(
+        count = count ?: 0,
+        next ?: "",
+        previous ?: "",
+        results = results?.map { it.toDomainObject() })
+}

--- a/app/src/main/java/com/sandoval/mypokedex/data/models/pokedex_list/Result.kt
+++ b/app/src/main/java/com/sandoval/mypokedex/data/models/pokedex_list/Result.kt
@@ -1,6 +1,9 @@
 package com.sandoval.mypokedex.data.models.pokedex_list
 
+import com.sandoval.mypokedex.domain.models.pokedex_list.DResult
+
 data class Result(
-    val name: String?,
-    val url: String?
-)
+    val name: String?, val url: String?
+) {
+    fun toDomainObject() = DResult(name = name ?: "", url = url ?: "")
+}

--- a/app/src/main/java/com/sandoval/mypokedex/data/network/Failure.kt
+++ b/app/src/main/java/com/sandoval/mypokedex/data/network/Failure.kt
@@ -1,0 +1,13 @@
+package com.sandoval.mypokedex.data.network
+
+sealed class Failure {
+
+    object NetworkConnection : Failure()
+    object DataError : Failure()
+    object ServerError : Failure()
+
+    //This class can be extended to be able to get specific errors
+    data class FeatureFailure(
+        val errorBody: String
+    ) : Failure()
+}

--- a/app/src/main/java/com/sandoval/mypokedex/data/remote/repository/pokedex_list/RemoteDataPokedexListRepository.kt
+++ b/app/src/main/java/com/sandoval/mypokedex/data/remote/repository/pokedex_list/RemoteDataPokedexListRepository.kt
@@ -1,12 +1,20 @@
 package com.sandoval.mypokedex.data.remote.repository.pokedex_list
 
+import com.sandoval.mypokedex.data.network.Failure
 import com.sandoval.mypokedex.data.remote.api.PokedexService
+import com.sandoval.mypokedex.data.utils.Either
+import com.sandoval.mypokedex.domain.models.pokedex_list.DResult
+import com.sandoval.mypokedex.domain.repository.pokedex_list.IGetPokedexListRepository
+import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
 class RemoteDataPokedexListRepository @Inject constructor(
     private val pokedexApiService: PokedexService
-) {
-    // Here the project will implement a repository interface from the domain layer
-    // Repository will use kotlin flow to emit the data from the service
-    // Repository will use a helper util class Either.kt to throw a left or right result.
+): IGetPokedexListRepository {
+
+    override suspend fun getPokedexList(limit: Int): Flow<Either<Failure, List<DResult>>> {
+        // Repository will use kotlin flow to emit the data from the service
+        // Repository will use a helper util class Either.kt to throw a left or right result.
+        TODO("Not yet implemented")
+    }
 }

--- a/app/src/main/java/com/sandoval/mypokedex/data/utils/Either.kt
+++ b/app/src/main/java/com/sandoval/mypokedex/data/utils/Either.kt
@@ -1,0 +1,63 @@
+package com.sandoval.mypokedex.data.utils
+
+/**
+ * Represents a value of one of two possible types (a disjoint union).
+ * Instances of [Either] are either an instance of [Left] or [Right].
+ * FP Convention dictates that [Left] is used for "failure"
+ * and [Right] is used for "success".
+ *
+ * @see Left
+ * @see Right
+ */
+sealed class Either<out L, out R> {
+    /** * Represents the left side of [Either] class which by convention is a "Failure". */
+    data class Left<out L>(val a: L) : Either<L, Nothing>()
+
+    /** * Represents the right side of [Either] class which by convention is a "Success". */
+    data class Right<out R>(val b: R) : Either<Nothing, R>()
+
+    /**
+     * Returns true if this is a Right, false otherwise.
+     * @see Right
+     */
+    val isRight get() = this is Right<R>
+
+    /**
+     * Returns true if this is a Left, false otherwise.
+     * @see Left
+     */
+    val isLeft get() = this is Left<L>
+
+    /**
+     * Creates a Left type.
+     * @see Left
+     */
+    fun <L> left(a: L) =
+        Left(a)
+
+    /**
+     * Creates a Left type.
+     * @see Right
+     */
+    fun <R> right(b: R) =
+        Right(b)
+
+    /**
+     * Applies fnL if this is a Left or fnR if this is a Right.
+     * @see Left
+     * @see Right
+     */
+    fun fold(fnL: (L) -> Any, fnR: (R) -> Any): Any =
+        when (this) {
+            is Left -> fnL(a)
+            is Right -> fnR(b)
+        }
+}
+
+/**
+ * Composes 2 functions
+ * See <a href="https://proandroiddev.com/kotlins-nothing-type-946de7d464fb">Credits to Alex Hart.</a>
+ */
+fun <A, B, C> ((A) -> B).c(f: (B) -> C): (A) -> C = {
+    f(this(it))
+}

--- a/app/src/main/java/com/sandoval/mypokedex/domain/base/BaseUseCase.kt
+++ b/app/src/main/java/com/sandoval/mypokedex/domain/base/BaseUseCase.kt
@@ -1,0 +1,26 @@
+package com.sandoval.mypokedex.domain.base
+
+import com.sandoval.mypokedex.data.network.Failure
+import com.sandoval.mypokedex.data.utils.Either
+import kotlinx.coroutines.*
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+
+abstract class BaseUseCase<in Params, out Type> where Type : Any {
+
+    abstract suspend fun run(params: Params): Flow<Either<Failure, Type>>
+
+    open operator fun invoke(
+        job: Job,
+        params: Params,
+        onResult: (Either<Failure, Type>) -> Unit = {}
+    ) {
+        val backgroundJob = CoroutineScope(job + Dispatchers.IO).async { run(params) }
+        CoroutineScope(job + Dispatchers.Main).launch {
+            val await = backgroundJob.await()
+            await.catch {
+                onResult(Either.Left(Failure.ServerError))
+            }.collect { d -> onResult(d) }
+        }
+    }
+}

--- a/app/src/main/java/com/sandoval/mypokedex/domain/models/pokedex_list/DPokedexListResponse.kt
+++ b/app/src/main/java/com/sandoval/mypokedex/domain/models/pokedex_list/DPokedexListResponse.kt
@@ -1,0 +1,5 @@
+package com.sandoval.mypokedex.domain.models.pokedex_list
+
+data class DPokedexListResponse(
+    val count: Int?, val next: String?, val previous: String?, val results: List<DResult>?
+)

--- a/app/src/main/java/com/sandoval/mypokedex/domain/models/pokedex_list/DResult.kt
+++ b/app/src/main/java/com/sandoval/mypokedex/domain/models/pokedex_list/DResult.kt
@@ -1,0 +1,5 @@
+package com.sandoval.mypokedex.domain.models.pokedex_list
+
+data class DResult(
+    val name: String?, val url: String?
+)

--- a/app/src/main/java/com/sandoval/mypokedex/domain/repository/pokedex_list/IGetPokedexListRepository.kt
+++ b/app/src/main/java/com/sandoval/mypokedex/domain/repository/pokedex_list/IGetPokedexListRepository.kt
@@ -1,0 +1,12 @@
+package com.sandoval.mypokedex.domain.repository.pokedex_list
+
+import com.sandoval.mypokedex.data.network.Failure
+import com.sandoval.mypokedex.data.utils.Either
+import com.sandoval.mypokedex.domain.models.pokedex_list.DResult
+import kotlinx.coroutines.flow.Flow
+
+interface IGetPokedexListRepository {
+
+    //get pokedex_list interface
+    suspend fun getPokedexList(limit: Int): Flow<Either<Failure, List<DResult>>>
+}

--- a/app/src/main/java/com/sandoval/mypokedex/domain/usecase/pokedex_list/GetPokedexListUseCase.kt
+++ b/app/src/main/java/com/sandoval/mypokedex/domain/usecase/pokedex_list/GetPokedexListUseCase.kt
@@ -1,0 +1,17 @@
+package com.sandoval.mypokedex.domain.usecase.pokedex_list
+
+import com.sandoval.mypokedex.data.network.Failure
+import com.sandoval.mypokedex.data.utils.Either
+import com.sandoval.mypokedex.domain.base.BaseUseCase
+import com.sandoval.mypokedex.domain.models.pokedex_list.DResult
+import com.sandoval.mypokedex.domain.repository.pokedex_list.IGetPokedexListRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class GetPokedexListUseCase @Inject constructor(
+    private val iGetPokedexListRepository: IGetPokedexListRepository
+) : BaseUseCase<Int, List<DResult>>() {
+    override suspend fun run(params: Int): Flow<Either<Failure, List<DResult>>> {
+        return iGetPokedexListRepository.getPokedexList(params)
+    }
+}


### PR DESCRIPTION
- Add the domain layer to map all the data results and operations through the domain.
- Add domain models to be mapped by the data layer in the future Add the repository interface to the domain to be implemented in the data layer and to be injected in the UseCase 
- Add the use case to get the pokedex list, to be injected through the viewmodel in the future Create 2 helper clases. Failure.kt to handle possible failure scenarios and Either.kt to be able to calculate the possible result of the operator when the usecase is consumed. Right (Success) Left (Error)