### PR TITLE
Add viewmodel and unit test of viewmodel for pokedex list feature

### DIFF
--- a/app/src/main/java/com/sandoval/mypokedex/commons/Constants.kt
+++ b/app/src/main/java/com/sandoval/mypokedex/commons/Constants.kt
@@ -1,12 +1,12 @@
 package com.sandoval.mypokedex.commons
 
-const val BASE_URL_POKEMON = "https://pokeapi.co/api/v2"
-const val POKEMON_LIST_PATH = "/pokemon" //Query limits
-const val POKEMON_LOCATION_PATH = "/location/{id}" // path id
-const val POKEMON_MOVES_PATH = "/move/{id}" // path id
-const val POKEMON_EVOLUTION_PATH = "/evolution-chain/{id}" // path id
-const val POKEMON_ABILITY_PATH = "/ability/{id}" // path id
-const val POKEMON_TYPE_PATH = "/type/{id}" // path id
+const val BASE_URL_POKEMON = "https://pokeapi.co/api/v2/"
+const val POKEMON_LIST_PATH = "pokemon" //Query limits
+const val POKEMON_LOCATION_PATH = "location/{id}" // path id
+const val POKEMON_MOVES_PATH = "move/{id}" // path id
+const val POKEMON_EVOLUTION_PATH = "evolution-chain/{id}" // path id
+const val POKEMON_ABILITY_PATH = "ability/{id}" // path id
+const val POKEMON_TYPE_PATH = "type/{id}" // path id
 
 const val BASE_URL_POKEMON_IMAGES =
     "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/{id-pokemon}.png"

--- a/app/src/main/java/com/sandoval/mypokedex/di/AppModule.kt
+++ b/app/src/main/java/com/sandoval/mypokedex/di/AppModule.kt
@@ -4,6 +4,8 @@ import com.google.gson.GsonBuilder
 import com.sandoval.mypokedex.BuildConfig
 import com.sandoval.mypokedex.commons.BASE_URL_POKEMON
 import com.sandoval.mypokedex.data.remote.api.PokedexService
+import com.sandoval.mypokedex.data.remote.repository.pokedex_list.RemoteDataPokedexListRepository
+import com.sandoval.mypokedex.domain.repository.pokedex_list.IGetPokedexListRepository
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -40,10 +42,10 @@ object AppModule {
     @Provides
     fun provideRetrofit(
         okHttpClient: OkHttpClient,
-        BASE_URL: String
+        BASE_URL_POKEMON: String
     ): Retrofit = Retrofit.Builder()
         .addConverterFactory(GsonConverterFactory.create(GsonBuilder().serializeNulls().create()))
-        .baseUrl(BASE_URL)
+        .baseUrl(BASE_URL_POKEMON)
         .client(okHttpClient)
         .build()
 
@@ -51,4 +53,9 @@ object AppModule {
     @Singleton
     fun provideApiService(retrofit: Retrofit): PokedexService =
         retrofit.create(PokedexService::class.java)
+
+    @Provides
+    @Singleton
+    fun providesGetPokedexList(remoteDataPokedexListRepository: RemoteDataPokedexListRepository): IGetPokedexListRepository =
+        remoteDataPokedexListRepository
 }

--- a/app/src/main/java/com/sandoval/mypokedex/ui/pokedex_list/model/state/GetPokedexListView.kt
+++ b/app/src/main/java/com/sandoval/mypokedex/ui/pokedex_list/model/state/GetPokedexListView.kt
@@ -1,0 +1,10 @@
+package com.sandoval.mypokedex.ui.pokedex_list.model.state
+
+import com.sandoval.mypokedex.domain.models.pokedex_list.DResult
+
+data class GetPokedexListView(
+    val loading: Boolean = false,
+    val errorMessage: String? = null,
+    val isEmpty: Boolean = false,
+    val pokedexList: List<DResult>? = null
+)

--- a/app/src/main/java/com/sandoval/mypokedex/ui/pokedex_list/viewmodel/GetPokedexListViewModel.kt
+++ b/app/src/main/java/com/sandoval/mypokedex/ui/pokedex_list/viewmodel/GetPokedexListViewModel.kt
@@ -1,0 +1,58 @@
+package com.sandoval.mypokedex.ui.pokedex_list.viewmodel
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import com.sandoval.mypokedex.data.network.Failure
+import com.sandoval.mypokedex.domain.models.pokedex_list.DResult
+import com.sandoval.mypokedex.domain.usecase.pokedex_list.GetPokedexListUseCase
+import com.sandoval.mypokedex.ui.pokedex_list.model.state.GetPokedexListView
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
+import javax.inject.Inject
+
+@HiltViewModel
+class GetPokedexListViewModel @Inject constructor(private val getPokedexListUseCase: GetPokedexListUseCase) :
+    ViewModel() {
+
+    private val job = Job()
+
+    private val _pokedexListViewModel = MutableLiveData<GetPokedexListView>()
+    val pokedexListViewModel: LiveData<GetPokedexListView> get() = _pokedexListViewModel
+
+    init {
+        getResults(151)
+    }
+
+    fun getResults(limit: Int) {
+        _pokedexListViewModel.value = GetPokedexListView(loading = true)
+        getPokedexListUseCase(job, limit) {
+            it.fold(
+                ::handleFailure,
+                ::handleSuccess
+            )
+        }
+    }
+
+    private fun handleSuccess(pokedexList: List<DResult>) {
+        if (pokedexList.isEmpty()) {
+            _pokedexListViewModel.value = GetPokedexListView(loading = false)
+            _pokedexListViewModel.value = GetPokedexListView(isEmpty = true)
+        } else {
+            _pokedexListViewModel.value = GetPokedexListView(loading = false)
+            _pokedexListViewModel.value =
+                GetPokedexListView(pokedexList = pokedexList)
+        }
+    }
+
+    private fun handleFailure(failure: Failure) {
+        _pokedexListViewModel.value = GetPokedexListView(loading = false)
+        _pokedexListViewModel.value =
+            GetPokedexListView(errorMessage = failure.toString())
+    }
+
+    override fun onCleared() {
+        job.cancel()
+        super.onCleared()
+    }
+}

--- a/app/src/test/java/com/sandoval/mypokedex/utils/LiveData.kt
+++ b/app/src/test/java/com/sandoval/mypokedex/utils/LiveData.kt
@@ -1,0 +1,47 @@
+package com.sandoval.mypokedex.utils
+
+import androidx.annotation.VisibleForTesting
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.Observer
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+
+/**
+ * Gets the value of a [LiveData] or waits for it to have one, with a timeout.
+ *
+ * Use this extension from host-side (JVM) tests. It's recommended to use it alongside
+ * `InstantTaskExecutorRule` or a similar mechanism to execute tasks synchronously.
+ */
+
+@VisibleForTesting(otherwise = VisibleForTesting.NONE)
+fun <T> LiveData<T>.getOrAwaitValueTest(
+    time: Long = 2,
+    timeUnit: TimeUnit = TimeUnit.SECONDS,
+    afterObserve: () -> Unit = {}
+): T {
+    var data: T? = null
+    val latch = CountDownLatch(1)
+    val observer = object : Observer<T> {
+        override fun onChanged(o: T?) {
+            data = o
+            latch.countDown()
+            this@getOrAwaitValueTest.removeObserver(this)
+        }
+    }
+    this.observeForever(observer)
+
+    try {
+        afterObserve.invoke()
+
+        // Don't wait indefinitely if the LiveData is not set.
+        if (!latch.await(time, timeUnit)) {
+            throw TimeoutException("LiveData value was never set.")
+        }
+    } finally {
+        this.removeObserver(observer)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    return data as T
+}

--- a/app/src/test/java/com/sandoval/mypokedex/viewmodel/pokedex_list/GetPokedexListViewModelTest.kt
+++ b/app/src/test/java/com/sandoval/mypokedex/viewmodel/pokedex_list/GetPokedexListViewModelTest.kt
@@ -1,0 +1,49 @@
+package com.sandoval.mypokedex.viewmodel.pokedex_list
+
+import com.google.common.truth.Truth
+import com.sandoval.mypokedex.data.network.Failure
+import com.sandoval.mypokedex.data.utils.Either
+import com.sandoval.mypokedex.domain.models.pokedex_list.DResult
+import com.sandoval.mypokedex.domain.usecase.pokedex_list.GetPokedexListUseCase
+import com.sandoval.mypokedex.ui.pokedex_list.viewmodel.GetPokedexListViewModel
+import com.sandoval.mypokedex.utils.UnitTest
+import com.sandoval.mypokedex.utils.getOrAwaitValueTest
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import org.junit.Before
+import org.junit.Test
+
+class GetPokedexListViewModelTest : UnitTest() {
+
+    @MockK
+    private lateinit var getPokedexListUseCase: GetPokedexListUseCase
+
+    private lateinit var getPokedexListViewModel: GetPokedexListViewModel
+
+    private lateinit var pokedexList: List<DResult>
+
+    @Before
+    fun setUp() {
+        pokedexList = listOf(
+            DResult(
+                name = "Bulbasur", url = "pokemon.com"
+            )
+        )
+
+        getPokedexListViewModel = GetPokedexListViewModel(getPokedexListUseCase)
+    }
+
+    @Test
+    fun `getPokedexList should return actual list`() {
+        every { getPokedexListUseCase(any(), 151, any()) }.answers {
+            lastArg<(Either<Failure, List<DResult>>) -> Unit>()(Either.Right(pokedexList))
+        }
+        getPokedexListViewModel.getResults(151)
+        val res = getPokedexListViewModel.pokedexListViewModel.getOrAwaitValueTest()
+        Truth.assertThat(res.errorMessage).isNull()
+        Truth.assertThat(res.loading).isFalse()
+        Truth.assertThat(res.isEmpty).isFalse()
+        Truth.assertThat(res.pokedexList).isEqualTo(pokedexList.map { it })
+    }
+
+}


### PR DESCRIPTION
- Add the view-model layer for the feature pokedex list
- Add a custom state class to map the possible states of the pokedex list use-case in a view model: loading, empty, error or data (GetPokedexListView.kt)
- Add a util class to be able to get the value of a LiveData, or waits for it to have one, with a timeout; to be used in the view-model unit-tests classes
- Add the view-model unit test for the Pokedex list use-case
- Fix minor bug regarding the base_url bad name in constants to be called in the DI
- Fix minor bug in the PATH constants due to escaped "/" character.