### PR TITLE
Render Pokedex List into Pokedex list fragment

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -38,6 +38,9 @@ val databindingCommonVersion = rootProject.extra.get("databinding_commons_versio
 //Lottie
 val lottieVersion = rootProject.extra.get("lottie_version") as String
 
+//Glide
+val glideVersion = rootProject.extra.get("glide_version") as String
+
 //Unit tests versions
 val androidArchTestVersion = rootProject.extra.get("android_arch_test_version") as String
 val mockkVersion = rootProject.extra.get("mockk_version") as String
@@ -84,6 +87,10 @@ val databindingCommonLibname = rootProject.extra.get("data_binding_common_libnam
 
 //Lottie
 val lottieLibname = rootProject.extra.get("lottie_libname") as String
+
+//Glide
+val glideLibname = rootProject.extra.get("glide_core_libname") as String
+val glideCompilerLibname = rootProject.extra.get("glide_compiler_libname") as String
 
 android {
     namespace = "com.sandoval.mypokedex"
@@ -163,4 +170,8 @@ dependencies {
 
     //Lottie
     implementation("$lottieLibname$lottieVersion")
+
+    //Glide
+    implementation("$glideLibname$glideVersion")
+    annotationProcessor("$glideCompilerLibname$glideVersion")
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.MyPokeDex"
+        android:usesCleartextTraffic="true"
         tools:targetApi="31">
         <activity
             android:name=".ui.MainActivity"

--- a/app/src/main/java/com/sandoval/mypokedex/ui/pokedex_list/adapter/PokedexListAdapter.kt
+++ b/app/src/main/java/com/sandoval/mypokedex/ui/pokedex_list/adapter/PokedexListAdapter.kt
@@ -1,0 +1,146 @@
+package com.sandoval.mypokedex.ui.pokedex_list.adapter
+
+import android.graphics.drawable.Drawable
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.core.view.isVisible
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.bumptech.glide.Glide
+import com.bumptech.glide.load.DataSource
+import com.bumptech.glide.load.engine.GlideException
+import com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions
+import com.bumptech.glide.request.RequestListener
+import com.bumptech.glide.request.target.Target
+import com.sandoval.mypokedex.databinding.ItemPokedexBinding
+import com.sandoval.mypokedex.domain.models.pokedex_list.DResult
+import com.sandoval.mypokedex.ui.utils.getPicUrl
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+class PokedexListAdapter :
+    ListAdapter<PokedexListItems, RecyclerView.ViewHolder>(PokedexListDiffCallback()) {
+
+    private val adapterScope = CoroutineScope(Dispatchers.Default)
+
+    override fun getItemViewType(position: Int): Int {
+        return when (getItem(position)) {
+            is PokedexListItems.PokedexItem -> 0
+            else -> throw ClassCastException("Unknown Type")
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
+        return when (viewType) {
+            0 -> PokedexListPreviewViewHolder.from(parent)
+            else -> throw ClassCastException("Unknown viewType $viewType")
+        }
+    }
+
+    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
+        val item = getItem(position)
+
+        when (holder) {
+            is PokedexListPreviewViewHolder -> {
+                val pokedexItem = item as PokedexListItems.PokedexItem
+                holder.bind(pokedexItem.results)
+            }
+        }
+    }
+
+    fun submitPokedexList(list: List<DResult>) {
+        adapterScope.launch {
+            val items = list.map {
+                PokedexListItems.PokedexItem(it)
+            }
+            withContext(Dispatchers.Main) {
+                submitList(items)
+            }
+        }
+    }
+
+    class PokedexListPreviewViewHolder private constructor(
+        val binding: ItemPokedexBinding
+    ) : RecyclerView.ViewHolder(binding.root) {
+
+        var picture: String? = ""
+
+        fun bind(
+            results: DResult
+        ) {
+            binding.results = results
+            loadImage(binding, results)
+            binding.executePendingBindings()
+        }
+
+        private fun loadImage(binding: ItemPokedexBinding, pokemonResult: DResult) {
+
+            picture = pokemonResult.url?.getPicUrl()
+
+            binding.apply {
+                Glide.with(root)
+                    .load(picture)
+                    .transition(DrawableTransitionOptions.withCrossFade())
+                    .listener(object : RequestListener<Drawable> {
+                        override fun onLoadFailed(
+                            e: GlideException?,
+                            model: Any?,
+                            target: Target<Drawable>?,
+                            isFirstResource: Boolean
+                        ): Boolean {
+                            progressCircular.isVisible = false
+                            return false
+                        }
+
+                        override fun onResourceReady(
+                            resource: Drawable?,
+                            model: Any?,
+                            target: Target<Drawable>?,
+                            dataSource: DataSource?,
+                            isFirstResource: Boolean
+                        ): Boolean {
+                            progressCircular.isVisible = false
+                            return false
+                        }
+
+                    })
+                    .into(pokemonItemImage)
+
+            }
+        }
+
+        companion object {
+            fun from(parent: ViewGroup): PokedexListPreviewViewHolder {
+                val layoutInflater = LayoutInflater.from(parent.context)
+                val binding = ItemPokedexBinding.inflate(layoutInflater, parent, false)
+                return PokedexListPreviewViewHolder(binding)
+            }
+        }
+    }
+}
+
+
+class PokedexListDiffCallback : DiffUtil.ItemCallback<PokedexListItems>() {
+    override fun areItemsTheSame(
+        oldItem: PokedexListItems, newItem: PokedexListItems
+    ): Boolean {
+        return oldItem.name == newItem.name
+    }
+
+    override fun areContentsTheSame(
+        oldItem: PokedexListItems, newItem: PokedexListItems
+    ): Boolean {
+        return oldItem == newItem
+    }
+}
+
+sealed class PokedexListItems {
+    data class PokedexItem(val results: DResult) : PokedexListItems() {
+        override val name = results.name ?: ""
+    }
+
+    abstract val name: String
+}

--- a/app/src/main/java/com/sandoval/mypokedex/ui/pokedex_list/fragments/PokedexListFragment.kt
+++ b/app/src/main/java/com/sandoval/mypokedex/ui/pokedex_list/fragments/PokedexListFragment.kt
@@ -3,10 +3,10 @@ package com.sandoval.mypokedex.ui.pokedex_list.fragments
 import android.util.Log
 import android.view.View
 import androidx.fragment.app.viewModels
-import androidx.navigation.fragment.findNavController
-import com.sandoval.mypokedex.R
+import androidx.recyclerview.widget.RecyclerView
 import com.sandoval.mypokedex.databinding.FragmentPokedexListBinding
 import com.sandoval.mypokedex.ui.base.BaseFragment
+import com.sandoval.mypokedex.ui.pokedex_list.adapter.PokedexListAdapter
 import com.sandoval.mypokedex.ui.pokedex_list.viewmodel.GetPokedexListViewModel
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -16,12 +16,18 @@ class PokedexListFragment : BaseFragment<FragmentPokedexListBinding>(
 ) {
 
     private val getPokedexListViewModel: GetPokedexListViewModel by viewModels()
+    private lateinit var pokedexListAdapter: PokedexListAdapter
 
     override fun initViews() {
-
-        binding.goToDetail.setOnClickListener {
-            findNavController().navigate(R.id.action_navigation_pokedex_list_fragment_to_navigation_pokedex_detail_fragment)
+        pokedexListAdapter = PokedexListAdapter()
+        pokedexListAdapter.apply {
+            registerAdapterDataObserver(object : RecyclerView.AdapterDataObserver() {
+                override fun onItemRangeChanged(positionStart: Int, itemCount: Int) {
+                    binding.pokedexList.smoothScrollToPosition(0)
+                }
+            })
         }
+        setupPokedexListRecycler()
     }
 
     override fun initViewModels() {
@@ -33,18 +39,26 @@ class PokedexListFragment : BaseFragment<FragmentPokedexListBinding>(
                 }
                 it.isEmpty -> {
                     hideLoading()
+                    binding.pokedexList.visibility = View.GONE
                     Log.d("PokedexList Empty", "Empty...")
                 }
                 it.pokedexList != null -> {
                     hideLoading()
+                    pokedexListAdapter.submitPokedexList(it.pokedexList)
                     Log.d("PokedexList", it.pokedexList.toString())
                 }
                 it.errorMessage != null -> {
                     hideLoading()
+                    binding.pokedexList.visibility = View.GONE
                     Log.e("PokedexList Error", it.errorMessage.toString())
                 }
             }
         }
+    }
+
+    private fun setupPokedexListRecycler() {
+        binding.pokedexList.visibility = View.VISIBLE
+        binding.pokedexList.adapter = pokedexListAdapter
     }
 
     private fun showLoading() {

--- a/app/src/main/java/com/sandoval/mypokedex/ui/utils/Extensions.kt
+++ b/app/src/main/java/com/sandoval/mypokedex/ui/utils/Extensions.kt
@@ -1,0 +1,8 @@
+package com.sandoval.mypokedex.ui.utils
+
+fun String.extractId() = this.substringAfter("pokemon").replace("/", "").toInt()
+
+fun String.getPicUrl(): String {
+    val id = this.extractId()
+    return "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/${id}.png"
+}

--- a/app/src/main/res/layout/fragment_pokedex_list.xml
+++ b/app/src/main/res/layout/fragment_pokedex_list.xml
@@ -12,26 +12,27 @@
         android:layout_height="match_parent"
         tools:context=".ui.pokedex_list.fragments.PokedexListFragment">
 
-        <TextView
-            android:id="@+id/textView"
-            android:layout_width="0dp"
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/pokedex_list"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:layout_marginTop="16dp"
-            android:text="@string/app_name"
+            android:layout_marginStart="8dp"
+            android:layout_marginTop="8dp"
+            android:layout_marginEnd="8dp"
+            android:layout_marginBottom="8dp"
+            android:visibility="gone"
+            android:clipToPadding="false"
+            android:paddingStart="10dp"
+            android:paddingTop="10dp"
+            android:paddingEnd="10dp"
+            android:paddingBottom="?actionBarSize"
+            app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
+            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-
-        <Button
-            android:id="@+id/go_to_detail"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:layout_marginTop="8dp"
-            android:text="Go to pokemon details"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/textView" />
+            app:layout_constraintTop_toTopOf="parent"
+            app:spanCount="2"
+            tools:listitem="@layout/item_pokedex" />
 
         <include
             android:id="@+id/loading_spinner"

--- a/app/src/main/res/layout/item_pokedex.xml
+++ b/app/src/main/res/layout/item_pokedex.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:foreground="?android:selectableItemBackground">
+
+    <data>
+
+        <import type="android.view.View" />
+
+        <variable
+            name="results"
+            type="com.sandoval.mypokedex.domain.models.pokedex_list.DResult" />
+    </data>
+
+    <androidx.cardview.widget.CardView
+        android:id="@+id/card"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="10dp"
+        android:layout_marginEnd="10dp"
+        android:layout_marginBottom="24dp"
+        app:cardCornerRadius="12dp"
+        app:cardElevation="2dp"
+        app:cardPreventCornerOverlap="false">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <ImageView
+                android:id="@+id/pokemon_item_image"
+                android:layout_width="0dp"
+                android:layout_height="100dp"
+                android:contentDescription="@null"
+                android:scaleType="fitCenter"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+
+            <ProgressBar
+                android:id="@+id/progress_circular"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                app:layout_constraintBottom_toTopOf="@+id/pokemon_item_title"
+                app:layout_constraintEnd_toEndOf="@+id/pokemon_item_image"
+                app:layout_constraintStart_toStartOf="@+id/pokemon_item_image"
+                app:layout_constraintTop_toTopOf="@+id/pokemon_item_image" />
+
+            <TextView
+                android:id="@+id/pokemon_item_title"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:gravity="center_horizontal"
+                android:paddingTop="16dp"
+                android:paddingBottom="16dp"
+                android:text="@{results.name}"
+                android:textAppearance="?attr/textAppearanceListItem"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/pokemon_item_image"
+                tools:text="Bulbasur" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </androidx.cardview.widget.CardView>
+
+</layout>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,6 +25,7 @@ buildscript {
         set("databinding_compiler_version", "3.2.0-alpha10")
         set("databinding_commons_version", "7.3.0")
         set("lottie_version", "5.2.0")
+        set("glide_version", "4.13.2")
         /*
         Tests Versions of Tests Libraries
         Android Arch
@@ -71,6 +72,11 @@ buildscript {
         //Lottie library name
         set("lottie_libname", "com.airbnb.android:lottie:")
 
+        //Glide library name
+        set("glide_core_libname", "com.github.bumptech.glide:glide:")
+        set("glide_compiler_libname", "com.github.bumptech.glide:compiler:")
+
+
         //Test Libraries for Unit tests
         set("android_core_arch_test_libname","androidx.arch.core:core-testing:")
         set("mockk_test_libname","io.mockk:mockk:")
@@ -79,6 +85,7 @@ buildscript {
 
     }
 }
+
 plugins {
     id("com.android.application") version "7.3.0" apply false
     id("com.android.library") version "7.3.0" apply false


### PR DESCRIPTION
- Create the Pokedex List adapter to use in the Pokedex List fragment and populate the list of pokemons inside the recycler view
- Add to the Pokedex List fragment, population of the recycler view of the Pokedex list, when the viewmodel is getting successful data through the gerPokedexList use-case
- Add the value of the Pokedex List UI through the viewBinding components in the item_pokedex.xml
- Add the Pokedex List binding adapter to be able to load data, in this cases url images, through the xml without declaring any reference in the fragment to the views. Using Glide depedency
- Add to the project the security config .xml to be able to have clear traffic to load images and other data flowing through the REST api. Use the security config .xml in the manifest