### PR TITLE
Navigation to Pokedex detail

### DIFF
--- a/app/src/main/java/com/sandoval/mypokedex/ui/pokedex_detail/fragments/PokedexDetailFragment.kt
+++ b/app/src/main/java/com/sandoval/mypokedex/ui/pokedex_detail/fragments/PokedexDetailFragment.kt
@@ -1,5 +1,7 @@
 package com.sandoval.mypokedex.ui.pokedex_detail.fragments
 
+import android.util.Log
+import androidx.navigation.fragment.navArgs
 import com.sandoval.mypokedex.databinding.FragmentPokedexDetailBinding
 import com.sandoval.mypokedex.ui.base.BaseFragment
 import dagger.hilt.android.AndroidEntryPoint
@@ -8,8 +10,12 @@ import dagger.hilt.android.AndroidEntryPoint
 class PokedexDetailFragment : BaseFragment<FragmentPokedexDetailBinding>(
     FragmentPokedexDetailBinding::inflate
 ) {
-    override fun initViews() {
 
+    private val args by navArgs<PokedexDetailFragmentArgs>()
+    private var pokedexName: String? = null
+    override fun initViews() {
+        pokedexName = args.pokedexName
+        Log.d("PokedexName", pokedexName!!)
     }
 
     override fun initViewModels() {

--- a/app/src/main/java/com/sandoval/mypokedex/ui/pokedex_list/adapter/PokedexListAdapter.kt
+++ b/app/src/main/java/com/sandoval/mypokedex/ui/pokedex_list/adapter/PokedexListAdapter.kt
@@ -25,7 +25,9 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
-class PokedexListAdapter :
+class PokedexListAdapter(
+    private val onPokedexListItemListener: PokedexListItemListener
+) :
     ListAdapter<PokedexListItems, RecyclerView.ViewHolder>(PokedexListDiffCallback()) {
 
     private val adapterScope = CoroutineScope(Dispatchers.Default)
@@ -50,7 +52,7 @@ class PokedexListAdapter :
         when (holder) {
             is PokedexListPreviewViewHolder -> {
                 val pokedexItem = item as PokedexListItems.PokedexItem
-                holder.bind(pokedexItem.results)
+                holder.bind(pokedexItem.results, onPokedexListItemListener)
             }
         }
     }
@@ -73,9 +75,11 @@ class PokedexListAdapter :
         var picture: String? = ""
 
         fun bind(
-            results: DResult
+            results: DResult,
+            onPokedexListItemListener: PokedexListItemListener
         ) {
             binding.results = results
+            binding.pokedexListener = onPokedexListItemListener
             loadImage(binding, results)
             binding.executePendingBindings()
         }

--- a/app/src/main/java/com/sandoval/mypokedex/ui/pokedex_list/adapter/PokedexListItemListener.kt
+++ b/app/src/main/java/com/sandoval/mypokedex/ui/pokedex_list/adapter/PokedexListItemListener.kt
@@ -1,0 +1,8 @@
+package com.sandoval.mypokedex.ui.pokedex_list.adapter
+
+class PokedexListItemListener(
+    val onPokedexListItemClickListener: (String) -> Unit
+) {
+    fun onPokedexListItemClicked(pokedexName: String) =
+        onPokedexListItemClickListener(pokedexName)
+}

--- a/app/src/main/java/com/sandoval/mypokedex/ui/pokedex_list/fragments/PokedexListFragment.kt
+++ b/app/src/main/java/com/sandoval/mypokedex/ui/pokedex_list/fragments/PokedexListFragment.kt
@@ -3,10 +3,12 @@ package com.sandoval.mypokedex.ui.pokedex_list.fragments
 import android.util.Log
 import android.view.View
 import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.RecyclerView
 import com.sandoval.mypokedex.databinding.FragmentPokedexListBinding
 import com.sandoval.mypokedex.ui.base.BaseFragment
 import com.sandoval.mypokedex.ui.pokedex_list.adapter.PokedexListAdapter
+import com.sandoval.mypokedex.ui.pokedex_list.adapter.PokedexListItemListener
 import com.sandoval.mypokedex.ui.pokedex_list.viewmodel.GetPokedexListViewModel
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -19,7 +21,13 @@ class PokedexListFragment : BaseFragment<FragmentPokedexListBinding>(
     private lateinit var pokedexListAdapter: PokedexListAdapter
 
     override fun initViews() {
-        pokedexListAdapter = PokedexListAdapter()
+        pokedexListAdapter = PokedexListAdapter(
+            onPokedexListItemListener = PokedexListItemListener {pokedexName ->
+                val action =
+                    PokedexListFragmentDirections.actionNavigationPokedexListFragmentToNavigationPokedexDetailFragment(pokedexName)
+                findNavController().navigate(action)
+            }
+        )
         pokedexListAdapter.apply {
             registerAdapterDataObserver(object : RecyclerView.AdapterDataObserver() {
                 override fun onItemRangeChanged(positionStart: Int, itemCount: Int) {

--- a/app/src/main/res/layout/item_pokedex.xml
+++ b/app/src/main/res/layout/item_pokedex.xml
@@ -11,6 +11,11 @@
         <variable
             name="results"
             type="com.sandoval.mypokedex.domain.models.pokedex_list.DResult" />
+
+        <variable
+            name="pokedexListener"
+            type="com.sandoval.mypokedex.ui.pokedex_list.adapter.PokedexListItemListener" />
+
     </data>
 
     <androidx.cardview.widget.CardView
@@ -20,6 +25,7 @@
         android:layout_marginStart="10dp"
         android:layout_marginEnd="10dp"
         android:layout_marginBottom="24dp"
+        android:onClick="@{()->pokedexListener.onPokedexListItemClicked(results.name)}"
         app:cardCornerRadius="12dp"
         app:cardElevation="2dp"
         app:cardPreventCornerOverlap="false">
@@ -55,9 +61,9 @@
                 android:gravity="center_horizontal"
                 android:paddingTop="16dp"
                 android:paddingBottom="16dp"
-                android:textSize="12sp"
                 android:text="@{results.name}"
                 android:textAppearance="?attr/textAppearanceListItem"
+                android:textSize="12sp"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/navigation/pokedex_navigation.xml
+++ b/app/src/main/res/navigation/pokedex_navigation.xml
@@ -18,6 +18,10 @@
         android:id="@+id/navigation_pokedex_detail_fragment"
         android:name="com.sandoval.mypokedex.ui.pokedex_detail.fragments.PokedexDetailFragment"
         android:label="Pokemon Detail"
-        tools:layout="@layout/fragment_pokedex_detail" />
+        tools:layout="@layout/fragment_pokedex_detail">
+        <argument
+            android:name="pokedexName"
+            app:argType="string" />
+    </fragment>
 
 </navigation>


### PR DESCRIPTION
- Add pokedexlistener class to implement in the adapter as an argument for navigate to list to detail in pokedex app
- Add through binding the listener implementation on click to navigate and pass the name of the pokemon from the pokedex list to the pokedex detail
- Log the pokemon name in the pokedex detail fragment