### PR TITLE
Add the implementation of the pokedex detail feature

### DIFF
--- a/app/src/main/java/com/sandoval/mypokedex/commons/Constants.kt
+++ b/app/src/main/java/com/sandoval/mypokedex/commons/Constants.kt
@@ -2,11 +2,9 @@ package com.sandoval.mypokedex.commons
 
 const val BASE_URL_POKEMON = "https://pokeapi.co/api/v2/"
 const val POKEMON_LIST_PATH = "pokemon" //Query limits
-const val POKEMON_LOCATION_PATH = "location/{id}" // path id
-const val POKEMON_MOVES_PATH = "move/{id}" // path id
-const val POKEMON_EVOLUTION_PATH = "evolution-chain/{id}" // path id
-const val POKEMON_ABILITY_PATH = "ability/{id}" // path id
-const val POKEMON_TYPE_PATH = "type/{id}" // path id
+const val POKEMON_DETAIL_PATH = "pokemon{name}" //Query limits
+const val POKEMON_LOCATION_PATH = "location/{name}" // path id
+const val POKEMON_EVOLUTION_PATH = "evolution-chain/{name}" // path id
 
 const val BASE_URL_POKEMON_IMAGES =
     "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/{id-pokemon}.png"

--- a/app/src/main/java/com/sandoval/mypokedex/data/models/pokedex_detail/Abilities.kt
+++ b/app/src/main/java/com/sandoval/mypokedex/data/models/pokedex_detail/Abilities.kt
@@ -1,0 +1,11 @@
+package com.sandoval.mypokedex.data.models.pokedex_detail
+
+import com.sandoval.mypokedex.domain.models.pokedex_detail.DAbilites
+
+data class Abilities(
+    val ability: Ability?
+) {
+    fun toDomainObject() = DAbilites(
+        ability = ability?.toDomainObject()
+    )
+}

--- a/app/src/main/java/com/sandoval/mypokedex/data/models/pokedex_detail/Ability.kt
+++ b/app/src/main/java/com/sandoval/mypokedex/data/models/pokedex_detail/Ability.kt
@@ -1,0 +1,13 @@
+package com.sandoval.mypokedex.data.models.pokedex_detail
+
+import com.sandoval.mypokedex.domain.models.pokedex_detail.DAbility
+
+data class Ability(
+    val name: String?,
+    val url: String?
+) {
+    fun toDomainObject() = DAbility(
+        name = name ?: "",
+        url = url ?: ""
+    )
+}

--- a/app/src/main/java/com/sandoval/mypokedex/data/models/pokedex_detail/Move.kt
+++ b/app/src/main/java/com/sandoval/mypokedex/data/models/pokedex_detail/Move.kt
@@ -1,0 +1,13 @@
+package com.sandoval.mypokedex.data.models.pokedex_detail
+
+import com.sandoval.mypokedex.domain.models.pokedex_detail.DMove
+
+data class Move(
+    val name: String?,
+    val url: String?
+){
+    fun toDomainObject() = DMove(
+        name = name ?: "",
+        url = url ?: ""
+    )
+}

--- a/app/src/main/java/com/sandoval/mypokedex/data/models/pokedex_detail/Moves.kt
+++ b/app/src/main/java/com/sandoval/mypokedex/data/models/pokedex_detail/Moves.kt
@@ -1,0 +1,11 @@
+package com.sandoval.mypokedex.data.models.pokedex_detail
+
+import com.sandoval.mypokedex.domain.models.pokedex_detail.DMoves
+
+data class Moves(
+    val move: Move?
+){
+    fun toDomainObject () = DMoves(
+        move = move?.toDomainObject()
+    )
+}

--- a/app/src/main/java/com/sandoval/mypokedex/data/models/pokedex_detail/PokedexDetailResponse.kt
+++ b/app/src/main/java/com/sandoval/mypokedex/data/models/pokedex_detail/PokedexDetailResponse.kt
@@ -1,0 +1,17 @@
+package com.sandoval.mypokedex.data.models.pokedex_detail
+
+import com.sandoval.mypokedex.domain.models.pokedex_detail.DPokedexDetailResponse
+
+data class PokedexDetailResponse(
+    val abilities: List<Abilities>?,
+    val moves: List<Moves>?,
+    val name: String?,
+    val types: List<Types>?,
+) {
+    fun toDomainObject() = DPokedexDetailResponse(
+        abilities = abilities?.map { it.toDomainObject() } ?: emptyList(),
+        moves = moves?.map { it.toDomainObject() } ?: emptyList(),
+        name = name ?: "",
+        types = types?.map { it.toDomainObject() } ?: emptyList(),
+    )
+}

--- a/app/src/main/java/com/sandoval/mypokedex/data/models/pokedex_detail/Type.kt
+++ b/app/src/main/java/com/sandoval/mypokedex/data/models/pokedex_detail/Type.kt
@@ -1,0 +1,13 @@
+package com.sandoval.mypokedex.data.models.pokedex_detail
+
+import com.sandoval.mypokedex.domain.models.pokedex_detail.DType
+
+data class Type(
+    val name: String?,
+    val url: String?
+){
+    fun toDomainObject() = DType(
+        name = name ?: "",
+        url = url ?: ""
+    )
+}

--- a/app/src/main/java/com/sandoval/mypokedex/data/models/pokedex_detail/Types.kt
+++ b/app/src/main/java/com/sandoval/mypokedex/data/models/pokedex_detail/Types.kt
@@ -1,0 +1,11 @@
+package com.sandoval.mypokedex.data.models.pokedex_detail
+
+import com.sandoval.mypokedex.domain.models.pokedex_detail.DTypes
+
+data class Types(
+    val type: Type?
+) {
+    fun toDomainObject() = DTypes(
+        type = type?.toDomainObject()
+    )
+}

--- a/app/src/main/java/com/sandoval/mypokedex/data/remote/api/PokedexService.kt
+++ b/app/src/main/java/com/sandoval/mypokedex/data/remote/api/PokedexService.kt
@@ -1,9 +1,12 @@
 package com.sandoval.mypokedex.data.remote.api
 
+import com.sandoval.mypokedex.commons.POKEMON_DETAIL_PATH
 import com.sandoval.mypokedex.commons.POKEMON_LIST_PATH
+import com.sandoval.mypokedex.data.models.pokedex_detail.PokedexDetailResponse
 import com.sandoval.mypokedex.data.models.pokedex_list.PokedexListResponse
 import retrofit2.Response
 import retrofit2.http.GET
+import retrofit2.http.Path
 import retrofit2.http.Query
 
 interface PokedexService {
@@ -13,4 +16,10 @@ interface PokedexService {
     suspend fun getPokedexList(
         @Query("limit") limit: Int
     ): Response<PokedexListResponse>
+
+    //Get Pokedex List
+    @GET(POKEMON_DETAIL_PATH)
+    suspend fun getPokedexDetail(
+        @Path("name") name: String?
+    ): Response<PokedexDetailResponse>
 }

--- a/app/src/main/java/com/sandoval/mypokedex/data/remote/repository/pokedex_detail/RemoteDataPokedexDetailRepository.kt
+++ b/app/src/main/java/com/sandoval/mypokedex/data/remote/repository/pokedex_detail/RemoteDataPokedexDetailRepository.kt
@@ -1,0 +1,31 @@
+package com.sandoval.mypokedex.data.remote.repository.pokedex_detail
+
+import com.sandoval.mypokedex.data.network.Failure
+import com.sandoval.mypokedex.data.remote.api.PokedexService
+import com.sandoval.mypokedex.data.utils.Either
+import com.sandoval.mypokedex.domain.models.pokedex_detail.DPokedexDetailResponse
+import com.sandoval.mypokedex.domain.repository.pokedex_detail.IGetPokedexDetailRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import javax.inject.Inject
+
+class RemoteDataPokedexDetailRepository @Inject constructor(
+    private val pokedexService: PokedexService
+) : IGetPokedexDetailRepository {
+    override suspend fun getPokedexDetail(name: String?): Flow<Either<Failure, DPokedexDetailResponse>> =
+        flow {
+            val res = name?.let { pokedexService.getPokedexDetail(it) }
+            if (res != null) {
+                emit(
+                    when (res.isSuccessful) {
+                        true -> {
+                            res.body()?.let { it ->
+                                Either.Right(it.toDomainObject())
+                            } ?: Either.Left(Failure.DataError)
+                        }
+                        false -> Either.Left(Failure.ServerError)
+                    }
+                )
+            }
+        }
+}

--- a/app/src/main/java/com/sandoval/mypokedex/di/AppModule.kt
+++ b/app/src/main/java/com/sandoval/mypokedex/di/AppModule.kt
@@ -4,7 +4,9 @@ import com.google.gson.GsonBuilder
 import com.sandoval.mypokedex.BuildConfig
 import com.sandoval.mypokedex.commons.BASE_URL_POKEMON
 import com.sandoval.mypokedex.data.remote.api.PokedexService
+import com.sandoval.mypokedex.data.remote.repository.pokedex_detail.RemoteDataPokedexDetailRepository
 import com.sandoval.mypokedex.data.remote.repository.pokedex_list.RemoteDataPokedexListRepository
+import com.sandoval.mypokedex.domain.repository.pokedex_detail.IGetPokedexDetailRepository
 import com.sandoval.mypokedex.domain.repository.pokedex_list.IGetPokedexListRepository
 import dagger.Module
 import dagger.Provides
@@ -58,4 +60,9 @@ object AppModule {
     @Singleton
     fun providesGetPokedexList(remoteDataPokedexListRepository: RemoteDataPokedexListRepository): IGetPokedexListRepository =
         remoteDataPokedexListRepository
+
+    @Provides
+    @Singleton
+    fun providesGetPokedexDetail(remoteDataPokedexDetailRepository: RemoteDataPokedexDetailRepository): IGetPokedexDetailRepository =
+        remoteDataPokedexDetailRepository
 }

--- a/app/src/main/java/com/sandoval/mypokedex/domain/models/pokedex_detail/DAbilites.kt
+++ b/app/src/main/java/com/sandoval/mypokedex/domain/models/pokedex_detail/DAbilites.kt
@@ -1,0 +1,5 @@
+package com.sandoval.mypokedex.domain.models.pokedex_detail
+
+data class DAbilites(
+    val ability: DAbility?
+)

--- a/app/src/main/java/com/sandoval/mypokedex/domain/models/pokedex_detail/DAbility.kt
+++ b/app/src/main/java/com/sandoval/mypokedex/domain/models/pokedex_detail/DAbility.kt
@@ -1,0 +1,6 @@
+package com.sandoval.mypokedex.domain.models.pokedex_detail
+
+data class DAbility(
+    val name: String?,
+    val url: String?
+)

--- a/app/src/main/java/com/sandoval/mypokedex/domain/models/pokedex_detail/DMove.kt
+++ b/app/src/main/java/com/sandoval/mypokedex/domain/models/pokedex_detail/DMove.kt
@@ -1,0 +1,6 @@
+package com.sandoval.mypokedex.domain.models.pokedex_detail
+
+data class DMove(
+    val name: String?,
+    val url: String?
+)

--- a/app/src/main/java/com/sandoval/mypokedex/domain/models/pokedex_detail/DMoves.kt
+++ b/app/src/main/java/com/sandoval/mypokedex/domain/models/pokedex_detail/DMoves.kt
@@ -1,0 +1,5 @@
+package com.sandoval.mypokedex.domain.models.pokedex_detail
+
+data class DMoves(
+    val move: DMove?
+)

--- a/app/src/main/java/com/sandoval/mypokedex/domain/models/pokedex_detail/DPokedexDetailResponse.kt
+++ b/app/src/main/java/com/sandoval/mypokedex/domain/models/pokedex_detail/DPokedexDetailResponse.kt
@@ -1,0 +1,8 @@
+package com.sandoval.mypokedex.domain.models.pokedex_detail
+
+data class DPokedexDetailResponse(
+    val abilities: List<DAbilites>?,
+    val moves: List<DMoves>?,
+    val name: String?,
+    val types: List<DTypes>?,
+)

--- a/app/src/main/java/com/sandoval/mypokedex/domain/models/pokedex_detail/DType.kt
+++ b/app/src/main/java/com/sandoval/mypokedex/domain/models/pokedex_detail/DType.kt
@@ -1,0 +1,6 @@
+package com.sandoval.mypokedex.domain.models.pokedex_detail
+
+data class DType(
+    val name: String?,
+    val url: String?
+)

--- a/app/src/main/java/com/sandoval/mypokedex/domain/models/pokedex_detail/DTypes.kt
+++ b/app/src/main/java/com/sandoval/mypokedex/domain/models/pokedex_detail/DTypes.kt
@@ -1,0 +1,5 @@
+package com.sandoval.mypokedex.domain.models.pokedex_detail
+
+data class DTypes(
+    val type: DType?
+)

--- a/app/src/main/java/com/sandoval/mypokedex/domain/repository/pokedex_detail/IGetPokedexDetailRepository.kt
+++ b/app/src/main/java/com/sandoval/mypokedex/domain/repository/pokedex_detail/IGetPokedexDetailRepository.kt
@@ -1,0 +1,13 @@
+package com.sandoval.mypokedex.domain.repository.pokedex_detail
+
+import com.sandoval.mypokedex.data.network.Failure
+import com.sandoval.mypokedex.data.utils.Either
+import com.sandoval.mypokedex.domain.models.pokedex_detail.DPokedexDetailResponse
+import com.sandoval.mypokedex.domain.models.pokedex_list.DResult
+import kotlinx.coroutines.flow.Flow
+
+interface IGetPokedexDetailRepository {
+
+    //get pokedex_detail interface
+    suspend fun getPokedexDetail(name: String?): Flow<Either<Failure, DPokedexDetailResponse>>
+}

--- a/app/src/main/java/com/sandoval/mypokedex/domain/usecase/pokedex_detail/GetPokedexDetailUseCase.kt
+++ b/app/src/main/java/com/sandoval/mypokedex/domain/usecase/pokedex_detail/GetPokedexDetailUseCase.kt
@@ -1,0 +1,17 @@
+package com.sandoval.mypokedex.domain.usecase.pokedex_detail
+
+import com.sandoval.mypokedex.data.network.Failure
+import com.sandoval.mypokedex.data.utils.Either
+import com.sandoval.mypokedex.domain.base.BaseUseCase
+import com.sandoval.mypokedex.domain.models.pokedex_detail.DPokedexDetailResponse
+import com.sandoval.mypokedex.domain.repository.pokedex_detail.IGetPokedexDetailRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class GetPokedexDetailUseCase @Inject constructor(
+    private val iGetPokedexDetailRepository: IGetPokedexDetailRepository
+) : BaseUseCase<String?, DPokedexDetailResponse>() {
+    override suspend fun run(params: String?): Flow<Either<Failure, DPokedexDetailResponse>> {
+        return iGetPokedexDetailRepository.getPokedexDetail(params)
+    }
+}

--- a/app/src/main/java/com/sandoval/mypokedex/ui/pokedex_detail/model/state/GetPokedexDetailView.kt
+++ b/app/src/main/java/com/sandoval/mypokedex/ui/pokedex_detail/model/state/GetPokedexDetailView.kt
@@ -1,0 +1,10 @@
+package com.sandoval.mypokedex.ui.pokedex_detail.model.state
+
+import com.sandoval.mypokedex.domain.models.pokedex_detail.DPokedexDetailResponse
+
+data class GetPokedexDetailView(
+    val loading: Boolean = false,
+    val errorMessage: String? = null,
+    val isEmpty: Boolean = false,
+    val pokedexDetail: DPokedexDetailResponse? = null
+)

--- a/app/src/main/java/com/sandoval/mypokedex/ui/pokedex_detail/viewmodel/GetPokedexDetailViewModel.kt
+++ b/app/src/main/java/com/sandoval/mypokedex/ui/pokedex_detail/viewmodel/GetPokedexDetailViewModel.kt
@@ -1,0 +1,48 @@
+package com.sandoval.mypokedex.ui.pokedex_detail.viewmodel
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import com.sandoval.mypokedex.data.network.Failure
+import com.sandoval.mypokedex.domain.models.pokedex_detail.DPokedexDetailResponse
+import com.sandoval.mypokedex.domain.usecase.pokedex_detail.GetPokedexDetailUseCase
+import com.sandoval.mypokedex.ui.pokedex_detail.model.state.GetPokedexDetailView
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
+import javax.inject.Inject
+
+@HiltViewModel
+class GetPokedexDetailViewModel @Inject constructor(private val getPokedexDetailUseCase: GetPokedexDetailUseCase) :
+    ViewModel() {
+
+    private val job = Job()
+
+    private val _pokedexDetailViewModel = MutableLiveData<GetPokedexDetailView>()
+    val pokedexDetailViewModel: LiveData<GetPokedexDetailView> get() = _pokedexDetailViewModel
+
+    fun getResults(name: String) {
+        _pokedexDetailViewModel.value = GetPokedexDetailView(loading = true)
+        getPokedexDetailUseCase(job, name) {
+            it.fold(
+                ::handleFailure,
+                ::handleSuccess
+            )
+        }
+    }
+
+    private fun handleSuccess(pokedexDetail: DPokedexDetailResponse) {
+        _pokedexDetailViewModel.value = GetPokedexDetailView(loading = false)
+        _pokedexDetailViewModel.value = GetPokedexDetailView(pokedexDetail = pokedexDetail)
+    }
+
+    private fun handleFailure(failure: Failure) {
+        _pokedexDetailViewModel.value = GetPokedexDetailView(loading = false)
+        _pokedexDetailViewModel.value =
+            GetPokedexDetailView(errorMessage = failure.toString())
+    }
+
+    override fun onCleared() {
+        job.cancel()
+        super.onCleared()
+    }
+}

--- a/app/src/test/java/com/sandoval/mypokedex/data/pokedex_detail/RemoteDataPokedexDetailRepositoryTest.kt
+++ b/app/src/test/java/com/sandoval/mypokedex/data/pokedex_detail/RemoteDataPokedexDetailRepositoryTest.kt
@@ -1,0 +1,101 @@
+package com.sandoval.mypokedex.data.pokedex_detail
+
+import com.google.common.truth.Truth
+import com.sandoval.mypokedex.data.models.pokedex_detail.*
+import com.sandoval.mypokedex.data.network.Failure
+import com.sandoval.mypokedex.data.remote.api.PokedexService
+import com.sandoval.mypokedex.data.remote.repository.pokedex_detail.RemoteDataPokedexDetailRepository
+import com.sandoval.mypokedex.data.utils.Either
+import com.sandoval.mypokedex.utils.UnitTest
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import retrofit2.Response
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class RemoteDataPokedexDetailRepositoryTest : UnitTest() {
+
+    private lateinit var remoteDataPokedexDetailRepository: RemoteDataPokedexDetailRepository
+    private lateinit var pokedexDetailResponse: PokedexDetailResponse
+
+    @MockK
+    private lateinit var pokedexService: PokedexService
+
+    @MockK
+    private lateinit var resultResponse: Response<PokedexDetailResponse>
+
+    @Before
+    fun setUp() {
+        remoteDataPokedexDetailRepository = RemoteDataPokedexDetailRepository(pokedexService)
+        pokedexDetailResponse = PokedexDetailResponse(
+            abilities = listOf(
+                Abilities(
+                    ability = Ability(
+                        name = "name", url = ".com"
+                    )
+                )
+            ),
+            moves = listOf(
+                Moves(
+                    move = Move(
+                        name = "name", url = ".com"
+                    )
+                )
+            ),
+            name = "Bulbasaur",
+            types = listOf(
+                Types(
+                    type = Type(
+                        name = "name", url = ".com"
+                    )
+                )
+            ),
+        )
+    }
+
+    @Test
+    fun `Get pokedex detail without name should return data error`() = runTest {
+        every { resultResponse.body() } returns null
+        every { resultResponse.isSuccessful } returns true
+        coEvery { pokedexService.getPokedexDetail(null) } returns resultResponse
+
+        val results = remoteDataPokedexDetailRepository.getPokedexDetail(
+            null
+        )
+
+        results.collect { a ->
+            Truth.assertThat(a).isEqualTo(Either.Left(Failure.DataError))
+        }
+    }
+
+
+    @Test
+    fun `Get pokedex detail with null name should return server error when response is not successful`() =
+        runTest {
+            every { resultResponse.isSuccessful } returns false
+            coEvery { pokedexService.getPokedexDetail(null) } returns resultResponse
+
+            val results = remoteDataPokedexDetailRepository.getPokedexDetail(null)
+            results.collect { a ->
+                Truth.assertThat(a).isEqualTo(Either.Left(Failure.ServerError))
+            }
+        }
+
+    @ExperimentalCoroutinesApi
+    @Test
+    fun `Get pokedex detail service with name should return the response successful`() = runTest {
+        every { resultResponse.body() } returns pokedexDetailResponse
+        every { resultResponse.isSuccessful } returns true
+        coEvery { pokedexService.getPokedexDetail("bulbasaur") } returns resultResponse
+
+        val results = remoteDataPokedexDetailRepository.getPokedexDetail("bulbasaur")
+        results.collect { a ->
+            Truth.assertThat(a).isEqualTo(Either.Right(pokedexDetailResponse.toDomainObject()))
+        }
+    }
+
+}

--- a/app/src/test/java/com/sandoval/mypokedex/domain/pokedex_detail/GetPokedexDetailUseCaseTest.kt
+++ b/app/src/test/java/com/sandoval/mypokedex/domain/pokedex_detail/GetPokedexDetailUseCaseTest.kt
@@ -1,0 +1,67 @@
+package com.sandoval.mypokedex.domain.pokedex_detail
+
+import com.sandoval.mypokedex.data.utils.Either
+import com.sandoval.mypokedex.domain.models.pokedex_detail.*
+import com.sandoval.mypokedex.domain.repository.pokedex_detail.IGetPokedexDetailRepository
+import com.sandoval.mypokedex.domain.usecase.pokedex_detail.GetPokedexDetailUseCase
+import com.sandoval.mypokedex.utils.UnitTest
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.impl.annotations.MockK
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class GetPokedexDetailUseCaseTest : UnitTest() {
+
+    private lateinit var getPokedexDetailUseCase: GetPokedexDetailUseCase
+
+    @MockK
+    private lateinit var iGetPokedexDetailRepository: IGetPokedexDetailRepository
+
+    @Before
+    fun setUp() {
+        getPokedexDetailUseCase = GetPokedexDetailUseCase(iGetPokedexDetailRepository)
+    }
+
+    @Test
+    fun `should call getPokedexDetail from repository`() = runTest {
+        coEvery {
+            iGetPokedexDetailRepository.getPokedexDetail("Bulbasaur")
+        } returns flow {
+            emit(
+                Either.Right(
+                    DPokedexDetailResponse(
+                        abilities = listOf(
+                            DAbilites(
+                                ability = DAbility(
+                                    name = "name", url = ".com"
+                                )
+                            )
+                        ),
+                        moves = listOf(
+                            DMoves(
+                                move = DMove(
+                                    name = "name", url = ".com"
+                                )
+                            )
+                        ),
+                        name = "Bulbasaur",
+                        types = listOf(
+                            DTypes(
+                                type = DType(
+                                    name = "name", url = ".com"
+                                )
+                            )
+                        ),
+                    )
+                )
+            )
+        }
+        getPokedexDetailUseCase.run("Bulbasaur")
+        coVerify(exactly = 1) { iGetPokedexDetailRepository.getPokedexDetail("Bulbasaur") }
+    }
+}

--- a/app/src/test/java/com/sandoval/mypokedex/viewmodel/pokedex_detail/GetPokedexDetailViewModelTest.kt
+++ b/app/src/test/java/com/sandoval/mypokedex/viewmodel/pokedex_detail/GetPokedexDetailViewModelTest.kt
@@ -1,0 +1,67 @@
+package com.sandoval.mypokedex.viewmodel.pokedex_detail
+
+import com.google.common.truth.Truth
+import com.sandoval.mypokedex.data.network.Failure
+import com.sandoval.mypokedex.data.utils.Either
+import com.sandoval.mypokedex.domain.models.pokedex_detail.*
+import com.sandoval.mypokedex.domain.usecase.pokedex_detail.GetPokedexDetailUseCase
+import com.sandoval.mypokedex.ui.pokedex_detail.viewmodel.GetPokedexDetailViewModel
+import com.sandoval.mypokedex.utils.UnitTest
+import com.sandoval.mypokedex.utils.getOrAwaitValueTest
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import org.junit.Before
+import org.junit.Test
+
+class GetPokedexDetailViewModelTest : UnitTest() {
+
+    @MockK
+    private lateinit var getPokedexDetailUseCase: GetPokedexDetailUseCase
+
+    private lateinit var getPokedexDetailViewModel: GetPokedexDetailViewModel
+
+    private lateinit var pokedexDetail: DPokedexDetailResponse
+
+    @Before
+    fun setUp() {
+        pokedexDetail = DPokedexDetailResponse(
+            abilities = listOf(
+                DAbilites(
+                    ability = DAbility(
+                        name = "name", url = ".com"
+                    )
+                )
+            ),
+            moves = listOf(
+                DMoves(
+                    move = DMove(
+                        name = "name", url = ".com"
+                    )
+                )
+            ),
+            name = "Bulbasaur",
+            types = listOf(
+                DTypes(
+                    type = DType(
+                        name = "name", url = ".com"
+                    )
+                )
+            ),
+        )
+
+        getPokedexDetailViewModel = GetPokedexDetailViewModel(getPokedexDetailUseCase)
+    }
+
+    @Test
+    fun `getPokedexList should return actual list`() {
+        every { getPokedexDetailUseCase(any(), "Bulbasaur", any()) }.answers {
+            lastArg<(Either<Failure, DPokedexDetailResponse>) -> Unit>()(Either.Right(pokedexDetail))
+        }
+        getPokedexDetailViewModel.getResults("Bulbasaur")
+        val res = getPokedexDetailViewModel.pokedexDetailViewModel.getOrAwaitValueTest()
+        Truth.assertThat(res.errorMessage).isNull()
+        Truth.assertThat(res.loading).isFalse()
+        Truth.assertThat(res.isEmpty).isFalse()
+        Truth.assertThat(res.pokedexDetail).isEqualTo(pokedexDetail)
+    }
+}


### PR DESCRIPTION
- Add the view-model layer for the feature pokedex detail
- Add a custom state class to map the possible states of the  pokedex detail use-case in a view model: loading, empty, error or data (GetPokedexDetailView.kt)
- Add a util class to be able to get the value of a LiveData, or waits for it to have one, with a timeout; to be used in the view-model unit-tests classes
- Add the view-model unit test for the pokedex detail use-case