### PR TITLE
Render Image and name in pokedex detail fragment

### DIFF
--- a/app/src/main/java/com/sandoval/mypokedex/commons/Constants.kt
+++ b/app/src/main/java/com/sandoval/mypokedex/commons/Constants.kt
@@ -2,7 +2,7 @@ package com.sandoval.mypokedex.commons
 
 const val BASE_URL_POKEMON = "https://pokeapi.co/api/v2/"
 const val POKEMON_LIST_PATH = "pokemon" //Query limits
-const val POKEMON_DETAIL_PATH = "pokemon{name}" //Query limits
+const val POKEMON_DETAIL_PATH = "pokemon/{name}" //Query limits
 const val POKEMON_LOCATION_PATH = "location/{name}" // path id
 const val POKEMON_EVOLUTION_PATH = "evolution-chain/{name}" // path id
 

--- a/app/src/main/java/com/sandoval/mypokedex/data/models/pokedex_detail/PokedexDetailResponse.kt
+++ b/app/src/main/java/com/sandoval/mypokedex/data/models/pokedex_detail/PokedexDetailResponse.kt
@@ -7,11 +7,13 @@ data class PokedexDetailResponse(
     val moves: List<Moves>?,
     val name: String?,
     val types: List<Types>?,
+    val sprites: Sprites?
 ) {
     fun toDomainObject() = DPokedexDetailResponse(
         abilities = abilities?.map { it.toDomainObject() } ?: emptyList(),
         moves = moves?.map { it.toDomainObject() } ?: emptyList(),
         name = name ?: "",
         types = types?.map { it.toDomainObject() } ?: emptyList(),
+        sprites = sprites?.toDomainObject()
     )
 }

--- a/app/src/main/java/com/sandoval/mypokedex/data/models/pokedex_detail/Sprites.kt
+++ b/app/src/main/java/com/sandoval/mypokedex/data/models/pokedex_detail/Sprites.kt
@@ -1,0 +1,11 @@
+package com.sandoval.mypokedex.data.models.pokedex_detail
+
+import com.sandoval.mypokedex.domain.models.pokedex_detail.DSprites
+
+data class Sprites(
+    val front_default: String?
+) {
+    fun toDomainObject() = DSprites(
+        front_default = front_default ?: ""
+    )
+}

--- a/app/src/main/java/com/sandoval/mypokedex/domain/models/pokedex_detail/DPokedexDetailResponse.kt
+++ b/app/src/main/java/com/sandoval/mypokedex/domain/models/pokedex_detail/DPokedexDetailResponse.kt
@@ -1,8 +1,11 @@
 package com.sandoval.mypokedex.domain.models.pokedex_detail
 
+import com.sandoval.mypokedex.data.models.pokedex_detail.Sprites
+
 data class DPokedexDetailResponse(
     val abilities: List<DAbilites>?,
     val moves: List<DMoves>?,
     val name: String?,
     val types: List<DTypes>?,
+    val sprites: DSprites?
 )

--- a/app/src/main/java/com/sandoval/mypokedex/domain/models/pokedex_detail/DSprites.kt
+++ b/app/src/main/java/com/sandoval/mypokedex/domain/models/pokedex_detail/DSprites.kt
@@ -1,0 +1,5 @@
+package com.sandoval.mypokedex.domain.models.pokedex_detail
+
+data class DSprites(
+    val front_default: String?
+)

--- a/app/src/main/java/com/sandoval/mypokedex/ui/pokedex_detail/fragments/PokedexDetailFragment.kt
+++ b/app/src/main/java/com/sandoval/mypokedex/ui/pokedex_detail/fragments/PokedexDetailFragment.kt
@@ -1,25 +1,128 @@
 package com.sandoval.mypokedex.ui.pokedex_detail.fragments
 
+import android.graphics.drawable.BitmapDrawable
+import android.graphics.drawable.Drawable
 import android.util.Log
+import android.view.View
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
+import androidx.core.view.isVisible
+import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.navArgs
+import androidx.palette.graphics.Palette
+import com.bumptech.glide.Glide
+import com.bumptech.glide.load.DataSource
+import com.bumptech.glide.load.engine.GlideException
+import com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions
+import com.bumptech.glide.request.RequestListener
+import com.bumptech.glide.request.target.Target
+import com.sandoval.mypokedex.R
 import com.sandoval.mypokedex.databinding.FragmentPokedexDetailBinding
+import com.sandoval.mypokedex.domain.models.pokedex_detail.DPokedexDetailResponse
 import com.sandoval.mypokedex.ui.base.BaseFragment
+import com.sandoval.mypokedex.ui.pokedex_detail.viewmodel.GetPokedexDetailViewModel
 import dagger.hilt.android.AndroidEntryPoint
+
 
 @AndroidEntryPoint
 class PokedexDetailFragment : BaseFragment<FragmentPokedexDetailBinding>(
     FragmentPokedexDetailBinding::inflate
 ) {
 
+    private val getPokedexDetailViewModel: GetPokedexDetailViewModel by viewModels()
+
     private val args by navArgs<PokedexDetailFragmentArgs>()
     private var pokedexName: String? = null
     override fun initViews() {
         pokedexName = args.pokedexName
-        Log.d("PokedexName", pokedexName!!)
+        (activity as AppCompatActivity?)!!.supportActionBar!!.title = pokedexName
     }
 
     override fun initViewModels() {
+        getPokedexDetailViewModel.getResults(pokedexName!!)
+        getPokedexDetailViewModel.pokedexDetailViewModel.observe(viewLifecycleOwner) {
+            when {
+                it.loading -> {
+                    showLoading()
+                }
+                it.isEmpty -> {
+                    hideLoading()
+                }
+                it.pokedexDetail != null -> {
+                    hideLoading()
+                    loadImage(it.pokedexDetail)
+                    binding.pokemonItemTitle.text = it.pokedexDetail.name
+                    Log.d("PokedexDetail", it.pokedexDetail.toString())
+                }
+                it.errorMessage != null -> {
+                    hideLoading()
+                    Log.e("PokedexList Error", it.errorMessage.toString())
+                }
+            }
+        }
+    }
 
+    private fun showLoading() {
+        binding.loadingSpinner.loadingContainer.visibility = View.VISIBLE
+    }
+
+    private fun hideLoading() {
+        binding.loadingSpinner.loadingContainer.visibility = View.GONE
+    }
+
+    private fun loadImage(
+        detail: DPokedexDetailResponse
+    ) {
+        var dominantColor = 0
+        val picture = detail.sprites?.front_default
+
+        binding.apply {
+            Glide.with(root)
+                .load(picture)
+                .transition(DrawableTransitionOptions.withCrossFade())
+                .listener(object : RequestListener<Drawable> {
+                    override fun onLoadFailed(
+                        e: GlideException?,
+                        model: Any?,
+                        target: Target<Drawable>?,
+                        isFirstResource: Boolean
+                    ): Boolean {
+                        progressCircular.isVisible = false
+                        return false
+                    }
+
+                    override fun onResourceReady(
+                        resource: Drawable?,
+                        model: Any?,
+                        target: Target<Drawable>?,
+                        dataSource: DataSource?,
+                        isFirstResource: Boolean
+                    ): Boolean {
+
+                        val drawable = resource as BitmapDrawable
+                        val bitmap = drawable.bitmap
+                        Palette.Builder(bitmap).generate {
+                            it?.let { palette ->
+                                dominantColor = palette.getDominantColor(
+                                    ContextCompat.getColor(
+                                        root.context,
+                                        R.color.white
+                                    )
+                                )
+
+                                pokemonItemImage.setBackgroundColor(dominantColor)
+
+
+                            }
+                        }
+                        progressCircular.isVisible = false
+                        return false
+                    }
+
+                })
+                .into(pokemonItemImage)
+
+        }
     }
 
 }

--- a/app/src/main/res/layout/fragment_pokedex_detail.xml
+++ b/app/src/main/res/layout/fragment_pokedex_detail.xml
@@ -1,20 +1,86 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
 
     </data>
 
-    <FrameLayout
+    <androidx.constraintlayout.widget.ConstraintLayout
+        style="@style/ContainerBackground"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         tools:context=".ui.pokedex_detail.fragments.PokedexDetailFragment">
 
-        <TextView
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:text="Pokemon Detail Fragment" />
+        <androidx.cardview.widget.CardView
+            android:id="@+id/card"
+            android:layout_width="200dp"
+            android:layout_height="200dp"
+            android:layout_marginTop="24dp"
+            app:cardBackgroundColor="@android:color/transparent"
+            app:cardCornerRadius="12dp"
+            app:cardElevation="2dp"
+            app:cardPreventCornerOverlap="false"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
 
-    </FrameLayout>
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent">
+
+                <ImageView
+                    android:id="@+id/pokemon_item_image"
+                    android:layout_width="0dp"
+                    android:layout_height="0dp"
+                    android:contentDescription="@null"
+                    android:scaleType="centerCrop"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <ProgressBar
+                    android:id="@+id/progress_circular"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
+        </androidx.cardview.widget.CardView>
+
+        <TextView
+            android:id="@+id/pokemon_item_title"
+            style="@style/PokemonTitleText"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="24dp"
+            android:layout_marginEnd="24dp"
+            android:gravity="center_horizontal"
+            android:paddingTop="16dp"
+            android:paddingBottom="16dp"
+            android:textAppearance="?attr/textAppearanceListItem"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/card"
+            tools:text="Bulbasur" />
+
+        <include
+            android:id="@+id/loading_spinner"
+            layout="@layout/loading_pokemon"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/navigation/pokedex_navigation.xml
+++ b/app/src/main/res/navigation/pokedex_navigation.xml
@@ -17,7 +17,6 @@
     <fragment
         android:id="@+id/navigation_pokedex_detail_fragment"
         android:name="com.sandoval.mypokedex.ui.pokedex_detail.fragments.PokedexDetailFragment"
-        android:label="Pokemon Detail"
         tools:layout="@layout/fragment_pokedex_detail">
         <argument
             android:name="pokedexName"

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -18,6 +18,12 @@
         <item name="android:background">@color/dark_blue</item>
     </style>
 
+    <style name="PokemonTitleText">
+        <item name="android:textColor">@color/white</item>
+        <item name="android:textSize">18sp</item>
+        <item name="android:textStyle">bold</item>
+    </style>
+
     <style name="ActionBar.nameText" parent="TextAppearance.AppCompat.Widget.ActionBar.Title">
         <item name="android:textColor">@color/black</item>
         <item name="android:textStyle">bold</item>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -18,6 +18,12 @@
         <item name="android:background">@color/light_blue</item>
     </style>
 
+    <style name="PokemonTitleText">
+        <item name="android:textColor">@color/white</item>
+        <item name="android:textSize">18sp</item>
+        <item name="android:textStyle">bold</item>
+    </style>
+
     <style name="ActionBar.nameText" parent="TextAppearance.AppCompat.Widget.ActionBar.Title">
         <item name="android:textColor">@color/black</item>
         <item name="android:textStyle">bold</item>

--- a/app/src/test/java/com/sandoval/mypokedex/data/pokedex_detail/RemoteDataPokedexDetailRepositoryTest.kt
+++ b/app/src/test/java/com/sandoval/mypokedex/data/pokedex_detail/RemoteDataPokedexDetailRepositoryTest.kt
@@ -54,6 +54,9 @@ class RemoteDataPokedexDetailRepositoryTest : UnitTest() {
                     )
                 )
             ),
+            sprites = Sprites(
+                front_default = ".url"
+            )
         )
     }
 

--- a/app/src/test/java/com/sandoval/mypokedex/domain/pokedex_detail/GetPokedexDetailUseCaseTest.kt
+++ b/app/src/test/java/com/sandoval/mypokedex/domain/pokedex_detail/GetPokedexDetailUseCaseTest.kt
@@ -57,6 +57,9 @@ class GetPokedexDetailUseCaseTest : UnitTest() {
                                 )
                             )
                         ),
+                        sprites = DSprites(
+                            front_default = ".url"
+                        )
                     )
                 )
             )

--- a/app/src/test/java/com/sandoval/mypokedex/viewmodel/pokedex_detail/GetPokedexDetailViewModelTest.kt
+++ b/app/src/test/java/com/sandoval/mypokedex/viewmodel/pokedex_detail/GetPokedexDetailViewModelTest.kt
@@ -47,6 +47,9 @@ class GetPokedexDetailViewModelTest : UnitTest() {
                     )
                 )
             ),
+            sprites = DSprites(
+                front_default = ".url"
+            )
         )
 
         getPokedexDetailViewModel = GetPokedexDetailViewModel(getPokedexDetailUseCase)


### PR DESCRIPTION
- Add to the data layer, domain layer and unit-tests a property regarding the url to render the image of the pokemon selected. (Sprite)
- Add the viewmodel to the pokedex detail fragment and observe the data from the service consumption.
- Add to the pokedex detail fragment the posibility to render the image of the pokemon selected in the list using the property of the pokedex detail service (Sprite).